### PR TITLE
Make possible to disable default processing for quill

### DIFF
--- a/dist/quill.core.js
+++ b/dist/quill.core.js
@@ -4598,13 +4598,19 @@ var Keyboard = function (_Module) {
           suffix: suffixText
         };
 
-        // It makes possible to skip all key bindings for custom blots, i.e. fully html embed
-        var bindingToDiscardDefaultBindings = _this2.bindings[-1] || [];
-        var discarded = bindingToDiscardDefaultBindings.some(function (binding) {
-          return binding.handler.call(this, range, curContext) !== true;
-        });
-        if (discarded) {
-          return;
+        var selection = document.getSelection();
+        if (selection) {
+          var domNode = selection.baseNode;
+          while (domNode != null) {
+            var quillNode = _quill2.default.find(domNode);
+            if (quillNode) {
+              if (quillNode.disableDefaultKeyListener && quillNode.disableDefaultKeyListener()) {
+                return;
+              }
+              break;
+            }
+            domNode = domNode.parentElement;
+          }
         }
 
         var prevented = bindings.some(function (binding) {

--- a/dist/quill.core.js
+++ b/dist/quill.core.js
@@ -4597,6 +4597,16 @@ var Keyboard = function (_Module) {
           prefix: prefixText,
           suffix: suffixText
         };
+
+        // It makes possible to skip all key bindings for custom blots, i.e. fully html embed
+        var bindingToDiscardDefaultBindings = _this2.bindings[-1] || [];
+        var discarded = bindingToDiscardDefaultBindings.some(function (binding) {
+          return binding.handler.call(this, range, curContext) !== true;
+        });
+        if (discarded) {
+          return;
+        }
+
         var prevented = bindings.some(function (binding) {
           if (binding.collapsed != null && binding.collapsed !== curContext.collapsed) return false;
           if (binding.empty != null && binding.empty !== curContext.empty) return false;

--- a/dist/quill.js
+++ b/dist/quill.js
@@ -4598,13 +4598,19 @@ var Keyboard = function (_Module) {
           suffix: suffixText
         };
 
-        // It makes possible to skip all key bindings for custom blots, i.e. fully html embed
-        var bindingToDiscardDefaultBindings = _this2.bindings[-1] || [];
-        var discarded = bindingToDiscardDefaultBindings.some(function (binding) {
-          return binding.handler.call(this, range, curContext) !== true;
-        });
-        if (discarded) {
-          return;
+        var selection = document.getSelection();
+        if (selection) {
+          var domNode = selection.baseNode;
+          while (domNode != null) {
+            var quillNode = _quill2.default.find(domNode);
+            if (quillNode) {
+              if (quillNode.disableDefaultKeyListener && quillNode.disableDefaultKeyListener()) {
+                return;
+              }
+              break;
+            }
+            domNode = domNode.parentElement;
+          }
         }
 
         var prevented = bindings.some(function (binding) {

--- a/dist/quill.js
+++ b/dist/quill.js
@@ -4597,6 +4597,16 @@ var Keyboard = function (_Module) {
           prefix: prefixText,
           suffix: suffixText
         };
+
+        // It makes possible to skip all key bindings for custom blots, i.e. fully html embed
+        var bindingToDiscardDefaultBindings = _this2.bindings[-1] || [];
+        var discarded = bindingToDiscardDefaultBindings.some(function (binding) {
+          return binding.handler.call(this, range, curContext) !== true;
+        });
+        if (discarded) {
+          return;
+        }
+
         var prevented = bindings.some(function (binding) {
           if (binding.collapsed != null && binding.collapsed !== curContext.collapsed) return false;
           if (binding.empty != null && binding.empty !== curContext.empty) return false;

--- a/dist/unit.js
+++ b/dist/unit.js
@@ -4598,13 +4598,19 @@ var Keyboard = function (_Module) {
           suffix: suffixText
         };
 
-        // It makes possible to skip all key bindings for custom blots, i.e. fully html embed
-        var bindingToDiscardDefaultBindings = _this2.bindings[-1] || [];
-        var discarded = bindingToDiscardDefaultBindings.some(function (binding) {
-          return binding.handler.call(this, range, curContext) !== true;
-        });
-        if (discarded) {
-          return;
+        var selection = document.getSelection();
+        if (selection) {
+          var domNode = selection.baseNode;
+          while (domNode != null) {
+            var quillNode = _quill2.default.find(domNode);
+            if (quillNode) {
+              if (quillNode.disableDefaultKeyListener && quillNode.disableDefaultKeyListener()) {
+                return;
+              }
+              break;
+            }
+            domNode = domNode.parentElement;
+          }
         }
 
         var prevented = bindings.some(function (binding) {

--- a/dist/unit.js
+++ b/dist/unit.js
@@ -4597,6 +4597,16 @@ var Keyboard = function (_Module) {
           prefix: prefixText,
           suffix: suffixText
         };
+
+        // It makes possible to skip all key bindings for custom blots, i.e. fully html embed
+        var bindingToDiscardDefaultBindings = _this2.bindings[-1] || [];
+        var discarded = bindingToDiscardDefaultBindings.some(function (binding) {
+          return binding.handler.call(this, range, curContext) !== true;
+        });
+        if (discarded) {
+          return;
+        }
+
         var prevented = bindings.some(function (binding) {
           if (binding.collapsed != null && binding.collapsed !== curContext.collapsed) return false;
           if (binding.empty != null && binding.empty !== curContext.empty) return false;

--- a/modules/keyboard.js
+++ b/modules/keyboard.js
@@ -95,14 +95,21 @@ class Keyboard extends Module {
         suffix: suffixText
       };
 
-      // It makes possible to skip all key bindings for custom blots, i.e. fully html embed
-      let bindingToDiscardDefaultBindings = (this.bindings[-1] || []);
-      let discarded = bindingToDiscardDefaultBindings.some(function (binding) {
-          return binding.handler.call(this, range, curContext) !== true
-      });
-      if (discarded) {
-          return;
+      let selection = document.getSelection();
+      if (selection) {
+        let domNode = selection.baseNode;
+        while (domNode != null) {
+          let quillNode = Quill.find(domNode);
+          if (quillNode) {
+            if (quillNode.disableDefaultKeyListener && quillNode.disableDefaultKeyListener()) {
+              return
+            }
+            break
+          }
+          domNode = domNode.parentElement;
+        }
       }
+
 
       let prevented = bindings.some((binding) => {
         if (binding.collapsed != null && binding.collapsed !== curContext.collapsed) return false;

--- a/modules/keyboard.js
+++ b/modules/keyboard.js
@@ -94,6 +94,16 @@ class Keyboard extends Module {
         prefix: prefixText,
         suffix: suffixText
       };
+
+      // It makes possible to skip all key bindings for custom blots, i.e. fully html embed
+      let bindingToDiscardDefaultBindings = (this.bindings[-1] || []);
+      let discarded = bindingToDiscardDefaultBindings.some(function (binding) {
+          return binding.handler.call(this, range, curContext) !== true
+      });
+      if (discarded) {
+          return;
+      }
+
       let prevented = bindings.some((binding) => {
         if (binding.collapsed != null && binding.collapsed !== curContext.collapsed) return false;
         if (binding.empty != null && binding.empty !== curContext.empty) return false;


### PR DESCRIPTION
```
class Table extends BlockEmbed {
...
    disableDefaultKeyListener() {
        return true;
    }
}
```