### PR TITLE
Fix indent from quill toolbar

### DIFF
--- a/dist/quill.js
+++ b/dist/quill.js
@@ -9622,14 +9622,7 @@ Toolbar.DEFAULTS = {
       this.quill.format('direction', value, _quill2.default.sources.USER);
     },
     indent: function indent(value) {
-      var range = this.quill.getSelection();
-      var formats = this.quill.getFormat(range);
-      var indent = parseInt(formats.indent || 0);
-      if (value === '+1' || value === '-1') {
-        var modifier = value === '+1' ? 1 : -1;
-        if (formats.direction === 'rtl') modifier *= -1;
-        this.quill.format('indent', indent + modifier, _quill2.default.sources.USER);
-      }
+      this.quill.format('indent', value, _quill2.default.sources.USER);
     },
     link: function link(value) {
       if (value === true) {

--- a/dist/unit.js
+++ b/dist/unit.js
@@ -9622,14 +9622,7 @@ Toolbar.DEFAULTS = {
       this.quill.format('direction', value, _quill2.default.sources.USER);
     },
     indent: function indent(value) {
-      var range = this.quill.getSelection();
-      var formats = this.quill.getFormat(range);
-      var indent = parseInt(formats.indent || 0);
-      if (value === '+1' || value === '-1') {
-        var modifier = value === '+1' ? 1 : -1;
-        if (formats.direction === 'rtl') modifier *= -1;
-        this.quill.format('indent', indent + modifier, _quill2.default.sources.USER);
-      }
+      this.quill.format('indent', value, _quill2.default.sources.USER);
     },
     link: function link(value) {
       if (value === true) {

--- a/modules/toolbar.js
+++ b/modules/toolbar.js
@@ -226,14 +226,7 @@ Toolbar.DEFAULTS = {
       this.quill.format('direction', value, Quill.sources.USER);
     },
     indent: function(value) {
-      let range = this.quill.getSelection();
-      let formats = this.quill.getFormat(range);
-      let indent = parseInt(formats.indent || 0);
-      if (value === '+1' || value === '-1') {
-        let modifier = (value === '+1') ? 1 : -1;
-        if (formats.direction === 'rtl') modifier *= -1;
-        this.quill.format('indent', indent + modifier, Quill.sources.USER);
-      }
+      this.quill.format('indent', value, Quill.sources.USER);
     },
     link: function(value) {
       if (value === true) {


### PR DESCRIPTION
Quill has internal logic for +1/-1 indent, so this logic on toolbar's level only breaks it