### PR TITLE
Fix format bubbling

### DIFF
--- a/blots/block.js
+++ b/blots/block.js
@@ -162,7 +162,7 @@ Block.allowedChildren = [Inline, Parchment.Embed, TextBlot];
 function bubbleFormats(blot, formats = {}) {
   if (blot == null) return formats;
   if (typeof blot.formats === 'function') {
-    formats = extend(formats, blot.formats());
+    formats = extend(blot.formats(), formats);
   }
   if (blot.parent == null || blot.parent.blotName == 'scroll' || blot.parent.statics.scope !== blot.statics.scope) {
     return formats;

--- a/dist/quill.core.js
+++ b/dist/quill.core.js
@@ -997,7 +997,7 @@ function bubbleFormats(blot) {
 
   if (blot == null) return formats;
   if (typeof blot.formats === 'function') {
-    formats = (0, _extend2.default)(formats, blot.formats());
+    formats = (0, _extend2.default)(blot.formats(), formats);
   }
   if (blot.parent == null || blot.parent.blotName == 'scroll' || blot.parent.statics.scope !== blot.statics.scope) {
     return formats;

--- a/dist/quill.js
+++ b/dist/quill.js
@@ -997,7 +997,7 @@ function bubbleFormats(blot) {
 
   if (blot == null) return formats;
   if (typeof blot.formats === 'function') {
-    formats = (0, _extend2.default)(formats, blot.formats());
+    formats = (0, _extend2.default)(blot.formats(), formats);
   }
   if (blot.parent == null || blot.parent.blotName == 'scroll' || blot.parent.statics.scope !== blot.statics.scope) {
     return formats;

--- a/dist/unit.js
+++ b/dist/unit.js
@@ -997,7 +997,7 @@ function bubbleFormats(blot) {
 
   if (blot == null) return formats;
   if (typeof blot.formats === 'function') {
-    formats = (0, _extend2.default)(formats, blot.formats());
+    formats = (0, _extend2.default)(blot.formats(), formats);
   }
   if (blot.parent == null || blot.parent.blotName == 'scroll' || blot.parent.statics.scope !== blot.statics.scope) {
     return formats;


### PR DESCRIPTION
Seems like previously while bubbling, if the same format type was used in multiple levels of blots, quill took the topmost. Probably there were no such case, so nobody cared about it. With new List logic we have such a case and we need to take the bottommost ( most specific). It will allow us correctly calculate list type when we have `<ol><ul></ul></ol>`