### PR TITLE
Don't change selection on dangerouslyPasteHTML

### DIFF
--- a/dist/quill.core.js
+++ b/dist/quill.core.js
@@ -8282,11 +8282,9 @@ var Clipboard = function (_Module) {
 
       if (typeof index === 'string') {
         this.quill.setContents(this.convert(index), html);
-        this.quill.setSelection(0, _quill2.default.sources.SILENT);
       } else {
         var paste = this.convert(html);
         this.quill.updateContents(new _quillDelta2.default().retain(index).concat(paste), source);
-        this.quill.setSelection(index + paste.length(), _quill2.default.sources.SILENT);
       }
     }
   }, {

--- a/dist/quill.js
+++ b/dist/quill.js
@@ -9001,11 +9001,9 @@ var Clipboard = function (_Module) {
 
       if (typeof index === 'string') {
         this.quill.setContents(this.convert(index), html);
-        this.quill.setSelection(0, _quill2.default.sources.SILENT);
       } else {
         var paste = this.convert(html);
         this.quill.updateContents(new _quillDelta2.default().retain(index).concat(paste), source);
-        this.quill.setSelection(index + paste.length(), _quill2.default.sources.SILENT);
       }
     }
   }, {

--- a/dist/unit.js
+++ b/dist/unit.js
@@ -9001,11 +9001,9 @@ var Clipboard = function (_Module) {
 
       if (typeof index === 'string') {
         this.quill.setContents(this.convert(index), html);
-        this.quill.setSelection(0, _quill2.default.sources.SILENT);
       } else {
         var paste = this.convert(html);
         this.quill.updateContents(new _quillDelta2.default().retain(index).concat(paste), source);
-        this.quill.setSelection(index + paste.length(), _quill2.default.sources.SILENT);
       }
     }
   }, {

--- a/modules/clipboard.js
+++ b/modules/clipboard.js
@@ -97,11 +97,9 @@ class Clipboard extends Module {
   dangerouslyPasteHTML(index, html, source = Quill.sources.API) {
     if (typeof index === 'string') {
       this.quill.setContents(this.convert(index), html);
-      this.quill.setSelection(0, Quill.sources.SILENT);
     } else {
       let paste = this.convert(html);
       this.quill.updateContents(new Delta().retain(index).concat(paste), source);
-      this.quill.setSelection(index + paste.length(), Quill.sources.SILENT);
     }
   }
 


### PR DESCRIPTION
Quill editor may even be not focused when we call paste, so it's better not to touch selection.