### PR TITLE
Export bubbleFormats

### DIFF
--- a/dist/quill.js
+++ b/dist/quill.js
@@ -10168,6 +10168,8 @@ var _snow = __webpack_require__(62);
 
 var _snow2 = _interopRequireDefault(_snow);
 
+var _block = __webpack_require__(4);
+
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 _core2.default.register({
@@ -10227,7 +10229,10 @@ _core2.default.register({
   'ui/picker': _picker2.default,
   'ui/icon-picker': _iconPicker2.default,
   'ui/color-picker': _colorPicker2.default,
-  'ui/tooltip': _tooltip2.default
+  'ui/tooltip': _tooltip2.default,
+
+  'functions/bubbleFormats': _block.bubbleFormats
+
 }, true);
 
 exports.default = _core2.default;

--- a/dist/unit.js
+++ b/dist/unit.js
@@ -10168,6 +10168,8 @@ var _snow = __webpack_require__(62);
 
 var _snow2 = _interopRequireDefault(_snow);
 
+var _block = __webpack_require__(4);
+
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 _core2.default.register({
@@ -10227,7 +10229,10 @@ _core2.default.register({
   'ui/picker': _picker2.default,
   'ui/icon-picker': _iconPicker2.default,
   'ui/color-picker': _colorPicker2.default,
-  'ui/tooltip': _tooltip2.default
+  'ui/tooltip': _tooltip2.default,
+
+  'functions/bubbleFormats': _block.bubbleFormats
+
 }, true);
 
 exports.default = _core2.default;

--- a/quill.js
+++ b/quill.js
@@ -38,6 +38,7 @@ import Tooltip from './ui/tooltip';
 import BubbleTheme from './themes/bubble';
 import SnowTheme from './themes/snow';
 
+import { bubbleFormats } from './blots/block';
 
 Quill.register({
   'attributors/attribute/direction': DirectionAttribute,
@@ -97,7 +98,10 @@ Quill.register({
   'ui/picker': Picker,
   'ui/icon-picker': IconPicker,
   'ui/color-picker': ColorPicker,
-  'ui/tooltip': Tooltip
+  'ui/tooltip': Tooltip,
+
+  'functions/bubbleFormats': bubbleFormats
+
 }, true);
 
 


### PR DESCRIPTION
So that we can easily use it in SparkQuill without direct imports of internal quill parts