### PR TITLE
SPI-11518 - Use same behaviour as normal paste on dangerous paste

### DIFF
--- a/dist/quill.core.js
+++ b/dist/quill.core.js
@@ -9072,6 +9072,10 @@ var Clipboard = function (_Module) {
         }
       } else {
         var paste = this.convert(html);
+        if (this.shouldAddNewlineBeforePaste(paste, index)) {
+          paste = new _quillDelta2.default().insert("\n").concat(paste);
+        }
+        applyFormatToDelta(paste, this.quill.getFormat(index));
         this.quill.updateContents(new _quillDelta2.default().retain(index).concat(paste), source);
         if (this.quill.hasFocus()) {
           this.quill.setSelection(index + paste.length(), _quill2.default.sources.SILENT);

--- a/dist/quill.js
+++ b/dist/quill.js
@@ -9791,6 +9791,10 @@ var Clipboard = function (_Module) {
         }
       } else {
         var paste = this.convert(html);
+        if (this.shouldAddNewlineBeforePaste(paste, index)) {
+          paste = new _quillDelta2.default().insert("\n").concat(paste);
+        }
+        applyFormatToDelta(paste, this.quill.getFormat(index));
         this.quill.updateContents(new _quillDelta2.default().retain(index).concat(paste), source);
         if (this.quill.hasFocus()) {
           this.quill.setSelection(index + paste.length(), _quill2.default.sources.SILENT);

--- a/dist/unit.js
+++ b/dist/unit.js
@@ -9791,6 +9791,10 @@ var Clipboard = function (_Module) {
         }
       } else {
         var paste = this.convert(html);
+        if (this.shouldAddNewlineBeforePaste(paste, index)) {
+          paste = new _quillDelta2.default().insert("\n").concat(paste);
+        }
+        applyFormatToDelta(paste, this.quill.getFormat(index));
         this.quill.updateContents(new _quillDelta2.default().retain(index).concat(paste), source);
         if (this.quill.hasFocus()) {
           this.quill.setSelection(index + paste.length(), _quill2.default.sources.SILENT);
@@ -15079,40 +15083,51 @@ describe('Clipboard', function () {
       this.quill.setSelection(2, 5);
     });
 
-    it('paste', function (done) {
+    it('dangerousPasteSavesFormatting', function (done) {
       var _this = this;
+
+      this.quill = this.initialize(_core2.default, '<strong>0123</strong>');
+      this.quill.clipboard.dangerouslyPasteHTML(2, "!");
+      setTimeout(function () {
+        expect(_this.quill.root).toEqualHTML('<p><strong>01!23</strong></p>');
+        done();
+      }, 2);
+    });
+
+    it('paste', function (done) {
+      var _this2 = this;
 
       this.quill.clipboard.container.innerHTML = '<strong>|</strong>';
       this.quill.clipboard.onPaste({});
       setTimeout(function () {
-        expect(_this.quill.root).toEqualHTML('<p>01<strong>|</strong><em>7</em>8</p>');
-        expect(_this.quill.getSelection()).toEqual(new _selection.Range(3));
+        expect(_this2.quill.root).toEqualHTML('<p>01<strong>|</strong><em>7</em>8</p>');
+        expect(_this2.quill.getSelection()).toEqual(new _selection.Range(3));
         done();
       }, 2);
     });
 
     it('paste in Bold', function (done) {
-      var _this2 = this;
+      var _this3 = this;
 
       this.quill.setContents(new _quillDelta2.default().insert("AA", { bold: true }));
       this.quill.setSelection(1, 0);
       this.quill.clipboard.container.innerHTML = 'B';
       this.quill.clipboard.onPaste({});
       setTimeout(function () {
-        expect(_this2.quill.getContents()).toEqual(new _quillDelta2.default().insert("ABA", { bold: true }).insert("\n"));
+        expect(_this3.quill.getContents()).toEqual(new _quillDelta2.default().insert("ABA", { bold: true }).insert("\n"));
         done();
       }, 2);
     });
 
     it('paste list', function (done) {
-      var _this3 = this;
+      var _this4 = this;
 
       this.quill.setContents(new _quillDelta2.default().insert("AA"));
       this.quill.setSelection(1, 0);
       this.quill.clipboard.container.innerHTML = '<ul><li>B</li></ul>';
       this.quill.clipboard.onPaste({});
       setTimeout(function () {
-        expect(_this3.quill.getContents()).toEqual(new _quillDelta2.default().insert("A\nB").insert("\n", { list: "bullet" }).insert("A\n"));
+        expect(_this4.quill.getContents()).toEqual(new _quillDelta2.default().insert("A\nB").insert("\n", { list: "bullet" }).insert("A\n"));
         done();
       }, 2);
     });

--- a/modules/clipboard.js
+++ b/modules/clipboard.js
@@ -102,7 +102,11 @@ class Clipboard extends Module {
         this.quill.setSelection(0, Quill.sources.SILENT);
       }
     } else {
-      let paste = this.convert(html);
+      var paste = this.convert(html);
+      if (this.shouldAddNewlineBeforePaste(paste, index)) {
+        paste = new Delta().insert("\n").concat(paste);
+      }
+      applyFormatToDelta(paste, this.quill.getFormat(index))
       this.quill.updateContents(new Delta().retain(index).concat(paste), source);
       if (this.quill.hasFocus()) {
         this.quill.setSelection(index + paste.length(), Quill.sources.SILENT);

--- a/test/unit/modules/clipboard.js
+++ b/test/unit/modules/clipboard.js
@@ -10,6 +10,15 @@ describe('Clipboard', function() {
       this.quill.setSelection(2, 5);
     });
 
+    it('dangerousPasteSavesFormatting', function(done) {
+      this.quill = this.initialize(Quill, '<strong>0123</strong>');
+      this.quill.clipboard.dangerouslyPasteHTML(2, "!")
+      setTimeout(() => {
+        expect(this.quill.root).toEqualHTML('<p><strong>01!23</strong></p>');
+        done();
+      }, 2);
+    });
+
     it('paste', function(done) {
       this.quill.clipboard.container.innerHTML = '<strong>|</strong>';
       this.quill.clipboard.onPaste({});


### PR DESCRIPTION
If we are pasting list add newline before, the same way as for normal paste
As a useful side effect preserve current formatting. Like if we are pasting plain text in the middle of bold it will be bold.