### PR TITLE
Don't log warning when same component is registered

### DIFF
--- a/core/quill.js
+++ b/core/quill.js
@@ -43,7 +43,7 @@ class Quill {
         });
       }
     } else {
-      if (this.imports[path] != null && !overwrite) {
+      if (this.imports[path] != null && this.imports[path] != target && !overwrite) {
         debug.warn(`Overwriting ${path} with`, target);
       }
       this.imports[path] = target;

--- a/dist/quill.core.js
+++ b/dist/quill.core.js
@@ -1113,7 +1113,7 @@ var Quill = function () {
           });
         }
       } else {
-        if (this.imports[path] != null && !overwrite) {
+        if (this.imports[path] != null && this.imports[path] != target && !overwrite) {
           debug.warn('Overwriting ' + path + ' with', target);
         }
         this.imports[path] = target;

--- a/dist/quill.js
+++ b/dist/quill.js
@@ -1113,7 +1113,7 @@ var Quill = function () {
           });
         }
       } else {
-        if (this.imports[path] != null && !overwrite) {
+        if (this.imports[path] != null && this.imports[path] != target && !overwrite) {
           debug.warn('Overwriting ' + path + ' with', target);
         }
         this.imports[path] = target;

--- a/dist/unit.js
+++ b/dist/unit.js
@@ -1113,7 +1113,7 @@ var Quill = function () {
           });
         }
       } else {
-        if (this.imports[path] != null && !overwrite) {
+        if (this.imports[path] != null && this.imports[path] != target && !overwrite) {
           debug.warn('Overwriting ' + path + ' with', target);
         }
         this.imports[path] = target;


### PR DESCRIPTION
As we are using multiple Quill instances on the same screen, same component can be registered several times. There is no harm in it, so we can remove warning for this case