### PR TITLE
feat: add support of shadow DOM

### DIFF
--- a/core/emitter.js
+++ b/core/emitter.js
@@ -3,15 +3,14 @@ import logger from './logger';
 
 let debug = logger('quill:events');
 
+const supportsRootNode = ('getRootNode' in document);
 const EVENTS = ['selectionchange', 'mousedown', 'mouseup', 'click'];
+const EMITTERS = [];
 
 EVENTS.forEach(function(eventName) {
   document.addEventListener(eventName, (...args) => {
-    [].slice.call(document.querySelectorAll('.ql-container')).forEach((node) => {
-      // TODO use WeakMap
-      if (node.__quill && node.__quill.emitter) {
-        node.__quill.emitter.handleDOM(...args);
-      }
+    EMITTERS.forEach((em) => {
+      em.handleDOM(...args);
     });
   });
 });
@@ -21,6 +20,7 @@ class Emitter extends EventEmitter {
   constructor() {
     super();
     this.listeners = {};
+    EMITTERS.push(this);
     this.on('error', debug.error);
   }
 
@@ -30,8 +30,25 @@ class Emitter extends EventEmitter {
   }
 
   handleDOM(event, ...args) {
+    const target = (event.composedPath ? event.composedPath()[0] : event.target);
+    const containsNode = (node, target) => {
+      if (!supportsRootNode || target.getRootNode() === document) {
+        return node.contains(target);
+      }
+
+      while (!node.contains(target)) {
+        const root = target.getRootNode();
+        if (!root || !root.host) {
+          return false;
+        }
+        target = root.host;
+      }
+
+      return true;
+    };
+
     (this.listeners[event.type] || []).forEach(function({ node, handler }) {
-      if (event.target === node || node.contains(event.target)) {
+      if (target === node || containsNode(node, target)) {
         handler(event, ...args);
       }
     });

--- a/core/selection.js
+++ b/core/selection.js
@@ -22,6 +22,7 @@ class Selection {
     this.composing = false;
     this.mouseDown = false;
     this.root = this.scroll.domNode;
+    this.rootDocument = (this.root.getRootNode ? this.root.getRootNode() : document);
     this.cursor = Parchment.create('cursor', this);
     // savedRange is last non-null range
     this.lastRange = this.savedRange = new Range(0, 0);
@@ -168,8 +169,10 @@ class Selection {
   }
 
   getNativeRange() {
-    let selection = document.getSelection();
+    let selection = this.rootDocument.getSelection();
     if (selection == null || selection.rangeCount <= 0) return null;
+    // eslint-disable-next-line no-console
+    console.log(selection.getRangeAt(0))
     let nativeRange = selection.getRangeAt(0);
     if (nativeRange == null) return null;
     let range = this.normalizeNative(nativeRange);
@@ -185,7 +188,7 @@ class Selection {
   }
 
   hasFocus() {
-    return document.activeElement === this.root;
+    return this.rootDocument.activeElement === this.root;
   }
 
   normalizedToRange(range) {
@@ -279,7 +282,7 @@ class Selection {
     if (startNode != null && (this.root.parentNode == null || startNode.parentNode == null || endNode.parentNode == null)) {
       return;
     }
-    let selection = document.getSelection();
+    let selection = typeof this.rootDocument.getSelection === 'function' ? this.rootDocument.getSelection() : document.getSelection();
     if (selection == null) return;
     if (startNode != null) {
       if (!this.hasFocus()) this.root.focus();

--- a/core/selection.js
+++ b/core/selection.js
@@ -171,8 +171,6 @@ class Selection {
   getNativeRange() {
     let selection = this.rootDocument.getSelection();
     if (selection == null || selection.rangeCount <= 0) return null;
-    // eslint-disable-next-line no-console
-    console.log(selection.getRangeAt(0))
     let nativeRange = selection.getRangeAt(0);
     if (nativeRange == null) return null;
     let range = this.normalizeNative(nativeRange);

--- a/dist/quill.core.js
+++ b/dist/quill.core.js
@@ -2713,8 +2713,6 @@ var Selection = function () {
     value: function getNativeRange() {
       var selection = this.rootDocument.getSelection();
       if (selection == null || selection.rangeCount <= 0) return null;
-      // eslint-disable-next-line no-console
-      console.log(selection.getRangeAt(0));
       var nativeRange = selection.getRangeAt(0);
       if (nativeRange == null) return null;
       var range = this.normalizeNative(nativeRange);

--- a/dist/quill.js
+++ b/dist/quill.js
@@ -1906,7 +1906,9 @@ function _inherits(subClass, superClass) { if (typeof superClass !== "function" 
 
 var debug = (0, _logger2.default)('quill:events');
 
+var supportsRootNode = 'getRootNode' in document;
 var EVENTS = ['selectionchange', 'mousedown', 'mouseup', 'click'];
+var EMITTERS = [];
 
 EVENTS.forEach(function (eventName) {
   document.addEventListener(eventName, function () {
@@ -1914,13 +1916,8 @@ EVENTS.forEach(function (eventName) {
       args[_key] = arguments[_key];
     }
 
-    [].slice.call(document.querySelectorAll('.ql-container')).forEach(function (node) {
-      // TODO use WeakMap
-      if (node.__quill && node.__quill.emitter) {
-        var _node$__quill$emitter;
-
-        (_node$__quill$emitter = node.__quill.emitter).handleDOM.apply(_node$__quill$emitter, args);
-      }
+    EMITTERS.forEach(function (em) {
+      em.handleDOM.apply(em, args);
     });
   });
 });
@@ -1934,6 +1931,7 @@ var Emitter = function (_EventEmitter) {
     var _this = _possibleConstructorReturn(this, (Emitter.__proto__ || Object.getPrototypeOf(Emitter)).call(this));
 
     _this.listeners = {};
+    EMITTERS.push(_this);
     _this.on('error', debug.error);
     return _this;
   }
@@ -1951,11 +1949,28 @@ var Emitter = function (_EventEmitter) {
         args[_key2 - 1] = arguments[_key2];
       }
 
+      var target = event.composedPath ? event.composedPath()[0] : event.target;
+      var containsNode = function containsNode(node, target) {
+        if (!supportsRootNode || target.getRootNode() === document) {
+          return node.contains(target);
+        }
+
+        while (!node.contains(target)) {
+          var root = target.getRootNode();
+          if (!root || !root.host) {
+            return false;
+          }
+          target = root.host;
+        }
+
+        return true;
+      };
+
       (this.listeners[event.type] || []).forEach(function (_ref) {
         var node = _ref.node,
             handler = _ref.handler;
 
-        if (event.target === node || node.contains(event.target)) {
+        if (target === node || containsNode(node, target)) {
           handler.apply(undefined, [event].concat(args));
         }
       });
@@ -2500,6 +2515,7 @@ var Selection = function () {
     this.composing = false;
     this.mouseDown = false;
     this.root = this.scroll.domNode;
+    this.rootDocument = this.root.getRootNode ? this.root.getRootNode() : document;
     this.cursor = _parchment2.default.create('cursor', this);
     // savedRange is last non-null range
     this.lastRange = this.savedRange = new Range(0, 0);
@@ -2695,8 +2711,10 @@ var Selection = function () {
   }, {
     key: 'getNativeRange',
     value: function getNativeRange() {
-      var selection = document.getSelection();
+      var selection = this.rootDocument.getSelection();
       if (selection == null || selection.rangeCount <= 0) return null;
+      // eslint-disable-next-line no-console
+      console.log(selection.getRangeAt(0));
       var nativeRange = selection.getRangeAt(0);
       if (nativeRange == null) return null;
       var range = this.normalizeNative(nativeRange);
@@ -2714,7 +2732,7 @@ var Selection = function () {
   }, {
     key: 'hasFocus',
     value: function hasFocus() {
-      return document.activeElement === this.root;
+      return this.rootDocument.activeElement === this.root;
     }
   }, {
     key: 'normalizedToRange',
@@ -2842,7 +2860,7 @@ var Selection = function () {
       if (startNode != null && (this.root.parentNode == null || startNode.parentNode == null || endNode.parentNode == null)) {
         return;
       }
-      var selection = document.getSelection();
+      var selection = typeof this.rootDocument.getSelection === 'function' ? this.rootDocument.getSelection() : document.getSelection();
       if (selection == null) return;
       if (startNode != null) {
         if (!this.hasFocus()) this.root.focus();
@@ -10663,6 +10681,7 @@ function _possibleConstructorReturn(self, call) { if (!self) { throw new Referen
 
 function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
+var supportsRootNode = 'getRootNode' in document;
 var debug = (0, _logger2.default)('quill:toolbar');
 
 var Toolbar = function (_Module) {
@@ -10679,7 +10698,8 @@ var Toolbar = function (_Module) {
       quill.container.parentNode.insertBefore(container, quill.container);
       _this.container = container;
     } else if (typeof _this.options.container === 'string') {
-      _this.container = document.querySelector(_this.options.container);
+      var rootDocument = supportsRootNode ? quill.container.getRootNode() : document;
+      _this.container = rootDocument.querySelector(_this.options.container);
     } else {
       _this.container = _this.options.container;
     }

--- a/dist/quill.js
+++ b/dist/quill.js
@@ -2713,8 +2713,6 @@ var Selection = function () {
     value: function getNativeRange() {
       var selection = this.rootDocument.getSelection();
       if (selection == null || selection.rangeCount <= 0) return null;
-      // eslint-disable-next-line no-console
-      console.log(selection.getRangeAt(0));
       var nativeRange = selection.getRangeAt(0);
       if (nativeRange == null) return null;
       var range = this.normalizeNative(nativeRange);

--- a/dist/unit.js
+++ b/dist/unit.js
@@ -1906,7 +1906,9 @@ function _inherits(subClass, superClass) { if (typeof superClass !== "function" 
 
 var debug = (0, _logger2.default)('quill:events');
 
+var supportsRootNode = 'getRootNode' in document;
 var EVENTS = ['selectionchange', 'mousedown', 'mouseup', 'click'];
+var EMITTERS = [];
 
 EVENTS.forEach(function (eventName) {
   document.addEventListener(eventName, function () {
@@ -1914,13 +1916,8 @@ EVENTS.forEach(function (eventName) {
       args[_key] = arguments[_key];
     }
 
-    [].slice.call(document.querySelectorAll('.ql-container')).forEach(function (node) {
-      // TODO use WeakMap
-      if (node.__quill && node.__quill.emitter) {
-        var _node$__quill$emitter;
-
-        (_node$__quill$emitter = node.__quill.emitter).handleDOM.apply(_node$__quill$emitter, args);
-      }
+    EMITTERS.forEach(function (em) {
+      em.handleDOM.apply(em, args);
     });
   });
 });
@@ -1934,6 +1931,7 @@ var Emitter = function (_EventEmitter) {
     var _this = _possibleConstructorReturn(this, (Emitter.__proto__ || Object.getPrototypeOf(Emitter)).call(this));
 
     _this.listeners = {};
+    EMITTERS.push(_this);
     _this.on('error', debug.error);
     return _this;
   }
@@ -1951,11 +1949,28 @@ var Emitter = function (_EventEmitter) {
         args[_key2 - 1] = arguments[_key2];
       }
 
+      var target = event.composedPath ? event.composedPath()[0] : event.target;
+      var containsNode = function containsNode(node, target) {
+        if (!supportsRootNode || target.getRootNode() === document) {
+          return node.contains(target);
+        }
+
+        while (!node.contains(target)) {
+          var root = target.getRootNode();
+          if (!root || !root.host) {
+            return false;
+          }
+          target = root.host;
+        }
+
+        return true;
+      };
+
       (this.listeners[event.type] || []).forEach(function (_ref) {
         var node = _ref.node,
             handler = _ref.handler;
 
-        if (event.target === node || node.contains(event.target)) {
+        if (target === node || containsNode(node, target)) {
           handler.apply(undefined, [event].concat(args));
         }
       });
@@ -2500,6 +2515,7 @@ var Selection = function () {
     this.composing = false;
     this.mouseDown = false;
     this.root = this.scroll.domNode;
+    this.rootDocument = this.root.getRootNode ? this.root.getRootNode() : document;
     this.cursor = _parchment2.default.create('cursor', this);
     // savedRange is last non-null range
     this.lastRange = this.savedRange = new Range(0, 0);
@@ -2695,8 +2711,10 @@ var Selection = function () {
   }, {
     key: 'getNativeRange',
     value: function getNativeRange() {
-      var selection = document.getSelection();
+      var selection = this.rootDocument.getSelection();
       if (selection == null || selection.rangeCount <= 0) return null;
+      // eslint-disable-next-line no-console
+      console.log(selection.getRangeAt(0));
       var nativeRange = selection.getRangeAt(0);
       if (nativeRange == null) return null;
       var range = this.normalizeNative(nativeRange);
@@ -2714,7 +2732,7 @@ var Selection = function () {
   }, {
     key: 'hasFocus',
     value: function hasFocus() {
-      return document.activeElement === this.root;
+      return this.rootDocument.activeElement === this.root;
     }
   }, {
     key: 'normalizedToRange',
@@ -2842,7 +2860,7 @@ var Selection = function () {
       if (startNode != null && (this.root.parentNode == null || startNode.parentNode == null || endNode.parentNode == null)) {
         return;
       }
-      var selection = document.getSelection();
+      var selection = typeof this.rootDocument.getSelection === 'function' ? this.rootDocument.getSelection() : document.getSelection();
       if (selection == null) return;
       if (startNode != null) {
         if (!this.hasFocus()) this.root.focus();
@@ -10663,6 +10681,7 @@ function _possibleConstructorReturn(self, call) { if (!self) { throw new Referen
 
 function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
+var supportsRootNode = 'getRootNode' in document;
 var debug = (0, _logger2.default)('quill:toolbar');
 
 var Toolbar = function (_Module) {
@@ -10679,7 +10698,8 @@ var Toolbar = function (_Module) {
       quill.container.parentNode.insertBefore(container, quill.container);
       _this.container = container;
     } else if (typeof _this.options.container === 'string') {
-      _this.container = document.querySelector(_this.options.container);
+      var rootDocument = supportsRootNode ? quill.container.getRootNode() : document;
+      _this.container = rootDocument.querySelector(_this.options.container);
     } else {
       _this.container = _this.options.container;
     }

--- a/dist/unit.js
+++ b/dist/unit.js
@@ -2713,8 +2713,6 @@ var Selection = function () {
     value: function getNativeRange() {
       var selection = this.rootDocument.getSelection();
       if (selection == null || selection.rangeCount <= 0) return null;
-      // eslint-disable-next-line no-console
-      console.log(selection.getRangeAt(0));
       var nativeRange = selection.getRangeAt(0);
       if (nativeRange == null) return null;
       var range = this.normalizeNative(nativeRange);

--- a/modules/toolbar.js
+++ b/modules/toolbar.js
@@ -4,6 +4,7 @@ import Quill from '../core/quill';
 import logger from '../core/logger';
 import Module from '../core/module';
 
+const supportsRootNode = ('getRootNode' in document);
 let debug = logger('quill:toolbar');
 
 
@@ -16,7 +17,8 @@ class Toolbar extends Module {
       quill.container.parentNode.insertBefore(container, quill.container);
       this.container = container;
     } else if (typeof this.options.container === 'string') {
-      this.container = document.querySelector(this.options.container);
+      const rootDocument = (supportsRootNode ? quill.container.getRootNode() : document);
+      this.container = rootDocument.querySelector(this.options.container);
     } else {
       this.container = this.options.container;
     }


### PR DESCRIPTION
In some clients(DesktopSpark specially) have some issues related with global styles, that affect composer styles.

This PR add support of shadow DOM to quill, for fix this issues. 