### PR TITLE
SPX-8463 - Fix scroll on paste

### DIFF
--- a/dist/quill.core.js
+++ b/dist/quill.core.js
@@ -8896,9 +8896,6 @@ module.exports = function GetIntrinsic(name, allowMissing) {
 		if (value != null) {
 			if ($gOPD && (i + 1) >= parts.length) {
 				var desc = $gOPD(value, parts[i]);
-				if (!allowMissing && !(parts[i] in value)) {
-					throw new $TypeError('base intrinsic for ' + name + ' exists, but the property is not available.');
-				}
 				value = desc ? (desc.get || desc.value) : value[parts[i]];
 			} else {
 				value = value[parts[i]];
@@ -9552,30 +9549,25 @@ var Clipboard = function (_Module) {
   }, {
     key: 'onPaste',
     value: function onPaste(e) {
-      var _this2 = this;
-
       if (e.defaultPrevented || !this.quill.isEnabled()) return;
       if (e.target != null && e.target.tagName == "INPUT") return; // Disab;e Quill paste when inside of input(i.e. plecaholder)
-      var range = this.quill.getSelection();
+      e.preventDefault();
+      var range = this.quill.getSelection(true);
+      if (range == null) return;
+      var html = e.clipboardData.getData('text/html');
+      var text = e.clipboardData.getData('text/plain');
       var delta = new _quillDelta2.default().retain(range.index);
-      var scrollTop = this.quill.scrollingContainer.scrollTop;
-      this.container.focus();
-      this.quill.selection.update(_quill2.default.sources.SILENT);
-      setTimeout(function () {
-        var pasteDelta = _this2.convert();
-        pasteDelta = _this2.preprocessDeltaBeforePasteIntoIndex(pasteDelta, range.index);
-        delta = delta.concat(pasteDelta).delete(range.length);
-        _this2.quill.updateContents(delta, _quill2.default.sources.USER);
-        // range.length contributes to delta.length()
-        _this2.quill.setSelection(delta.length() - range.length, _quill2.default.sources.SILENT);
-        _this2.quill.scrollingContainer.scrollTop = scrollTop;
-        _this2.quill.focus();
-      }, 1);
+      var pasteDelta = this.convert(html || text);
+      pasteDelta = this.preprocessDeltaBeforePasteIntoIndex(pasteDelta, range.index);
+      delta = delta.concat(pasteDelta).delete(range.length);
+      this.quill.updateContents(delta, _quill2.default.sources.USER);
+      // range.length contributes to delta.length()
+      this.quill.setSelection(delta.length() - range.length, _quill2.default.sources.SILENT);
     }
   }, {
     key: 'prepareMatching',
     value: function prepareMatching() {
-      var _this3 = this;
+      var _this2 = this;
 
       var elementMatchers = [],
           textMatchers = [];
@@ -9592,7 +9584,7 @@ var Clipboard = function (_Module) {
             elementMatchers.push(matcher);
             break;
           default:
-            [].forEach.call(_this3.container.querySelectorAll(selector), function (node) {
+            [].forEach.call(_this2.container.querySelectorAll(selector), function (node) {
               // TODO use weakmap
               node[DOM_KEY] = node[DOM_KEY] || [];
               node[DOM_KEY].push(matcher);

--- a/dist/quill.js
+++ b/dist/quill.js
@@ -9615,9 +9615,6 @@ module.exports = function GetIntrinsic(name, allowMissing) {
 		if (value != null) {
 			if ($gOPD && (i + 1) >= parts.length) {
 				var desc = $gOPD(value, parts[i]);
-				if (!allowMissing && !(parts[i] in value)) {
-					throw new $TypeError('base intrinsic for ' + name + ' exists, but the property is not available.');
-				}
 				value = desc ? (desc.get || desc.value) : value[parts[i]];
 			} else {
 				value = value[parts[i]];
@@ -10271,30 +10268,25 @@ var Clipboard = function (_Module) {
   }, {
     key: 'onPaste',
     value: function onPaste(e) {
-      var _this2 = this;
-
       if (e.defaultPrevented || !this.quill.isEnabled()) return;
       if (e.target != null && e.target.tagName == "INPUT") return; // Disab;e Quill paste when inside of input(i.e. plecaholder)
-      var range = this.quill.getSelection();
+      e.preventDefault();
+      var range = this.quill.getSelection(true);
+      if (range == null) return;
+      var html = e.clipboardData.getData('text/html');
+      var text = e.clipboardData.getData('text/plain');
       var delta = new _quillDelta2.default().retain(range.index);
-      var scrollTop = this.quill.scrollingContainer.scrollTop;
-      this.container.focus();
-      this.quill.selection.update(_quill2.default.sources.SILENT);
-      setTimeout(function () {
-        var pasteDelta = _this2.convert();
-        pasteDelta = _this2.preprocessDeltaBeforePasteIntoIndex(pasteDelta, range.index);
-        delta = delta.concat(pasteDelta).delete(range.length);
-        _this2.quill.updateContents(delta, _quill2.default.sources.USER);
-        // range.length contributes to delta.length()
-        _this2.quill.setSelection(delta.length() - range.length, _quill2.default.sources.SILENT);
-        _this2.quill.scrollingContainer.scrollTop = scrollTop;
-        _this2.quill.focus();
-      }, 1);
+      var pasteDelta = this.convert(html || text);
+      pasteDelta = this.preprocessDeltaBeforePasteIntoIndex(pasteDelta, range.index);
+      delta = delta.concat(pasteDelta).delete(range.length);
+      this.quill.updateContents(delta, _quill2.default.sources.USER);
+      // range.length contributes to delta.length()
+      this.quill.setSelection(delta.length() - range.length, _quill2.default.sources.SILENT);
     }
   }, {
     key: 'prepareMatching',
     value: function prepareMatching() {
-      var _this3 = this;
+      var _this2 = this;
 
       var elementMatchers = [],
           textMatchers = [];
@@ -10311,7 +10303,7 @@ var Clipboard = function (_Module) {
             elementMatchers.push(matcher);
             break;
           default:
-            [].forEach.call(_this3.container.querySelectorAll(selector), function (node) {
+            [].forEach.call(_this2.container.querySelectorAll(selector), function (node) {
               // TODO use weakmap
               node[DOM_KEY] = node[DOM_KEY] || [];
               node[DOM_KEY].push(matcher);

--- a/modules/clipboard.js
+++ b/modules/clipboard.js
@@ -114,21 +114,18 @@ class Clipboard extends Module {
   onPaste(e) {
     if (e.defaultPrevented || !this.quill.isEnabled()) return;
     if (e.target != null && e.target.tagName == "INPUT") return; // Disab;e Quill paste when inside of input(i.e. plecaholder)
-    let range = this.quill.getSelection();
+    e.preventDefault();
+    const range = this.quill.getSelection(true);
+    if (range == null) return;
+    const html = e.clipboardData.getData('text/html');
+    const text = e.clipboardData.getData('text/plain');
     let delta = new Delta().retain(range.index);
-    let scrollTop = this.quill.scrollingContainer.scrollTop;
-    this.container.focus();
-    this.quill.selection.update(Quill.sources.SILENT);
-    setTimeout(() => {
-      let pasteDelta = this.convert();
-      pasteDelta = this.preprocessDeltaBeforePasteIntoIndex(pasteDelta, range.index);
-      delta = delta.concat(pasteDelta).delete(range.length);
-      this.quill.updateContents(delta, Quill.sources.USER);
-      // range.length contributes to delta.length()
-      this.quill.setSelection(delta.length() - range.length, Quill.sources.SILENT);
-      this.quill.scrollingContainer.scrollTop = scrollTop;
-      this.quill.focus();
-    }, 1);
+    let pasteDelta = this.convert(html || text);
+    pasteDelta = this.preprocessDeltaBeforePasteIntoIndex(pasteDelta, range.index);
+    delta = delta.concat(pasteDelta).delete(range.length);
+    this.quill.updateContents(delta, Quill.sources.USER);
+    // range.length contributes to delta.length()
+    this.quill.setSelection(delta.length() - range.length, Quill.sources.SILENT);
   }
 
   prepareMatching() {

--- a/test/unit/modules/clipboard.js
+++ b/test/unit/modules/clipboard.js
@@ -46,8 +46,8 @@ describe('Clipboard', function() {
     });
 
     it('paste', function(done) {
-      this.quill.clipboard.container.innerHTML = '<strong>|</strong>';
-      this.quill.clipboard.onPaste({});
+      let event = buildClipboardEvent('<strong>|</strong>', '|')
+      this.quill.clipboard.onPaste(event);
       setTimeout(() => {
         expect(this.quill.root).toEqualHTML('<p>01<strong>|</strong><em>7</em>8</p>');
         expect(this.quill.getSelection()).toEqual(new Range(3));
@@ -62,8 +62,8 @@ describe('Clipboard', function() {
                                       .insert('\n');
       this.quill.setContents(originalDelta);
       this.quill.setSelection(this.quill.getLength() - 1, 0);
-      this.quill.clipboard.container.innerHTML = 'Text';
-      this.quill.clipboard.onPaste({});
+      let event = buildClipboardEvent(null, 'Text')
+      this.quill.clipboard.onPaste(event);
       setTimeout(() => {
         expect(this.quill.getContents()).toEqual(expectedDelta);
         done();
@@ -73,8 +73,8 @@ describe('Clipboard', function() {
     it('paste in Bold', function(done) {
       this.quill.setContents(new Delta().insert("AA", {bold: true}));
       this.quill.setSelection(1, 0)
-      this.quill.clipboard.container.innerHTML = 'B';
-      this.quill.clipboard.onPaste({});
+      let event = buildClipboardEvent(null, 'B')
+      this.quill.clipboard.onPaste(event);
       setTimeout(() => {
         expect(this.quill.getContents()).toEqual(new Delta().insert("ABA", {bold: true}).insert("\n"));
         done();
@@ -84,8 +84,8 @@ describe('Clipboard', function() {
     it('paste list', function(done) {
       this.quill.setContents(new Delta().insert("AA"));
       this.quill.setSelection(1, 0)
-      this.quill.clipboard.container.innerHTML = '<ul><li>B</li></ul>';
-      this.quill.clipboard.onPaste({});
+      let event = buildClipboardEvent('<ul><li>B</li></ul>', 'B')
+      this.quill.clipboard.onPaste(event);
       setTimeout(() => {
         expect(this.quill.getContents()).toEqual(new Delta().insert("A\nB").insert("\n", {list:"bullet"}).insert("A\n"));
         done();
@@ -98,8 +98,8 @@ describe('Clipboard', function() {
       };
       spyOn(handler, 'change');
       this.quill.on('selection-change', handler.change);
-      this.quill.clipboard.container.innerHTML = '0';
-      this.quill.clipboard.onPaste({});
+      let event = buildClipboardEvent(null, 'B')
+      this.quill.clipboard.onPaste(event);
       setTimeout(function() {
         expect(handler.change).not.toHaveBeenCalled();
         done();
@@ -225,3 +225,14 @@ describe('Clipboard', function() {
     });
   });
 });
+
+function buildClipboardEvent(html, text) {
+  return {
+    clipboardData: {
+      getData: (type) => {
+        return type === 'text/html' ? html : text;
+      }
+    },
+    preventDefault: () => {},
+  }
+}


### PR DESCRIPTION
Previous way of pasting caused clipboard container to be focused, allow paste to it, and fetch the result to process
Current way doesn't rely on native mechanism, doing everything manually. Actually this way is based on implementation of Paste in Quill 2.0