### PR TITLE
SPC-2792 - Preserve original formatting, but use some exceptions - list and quote

### DIFF
--- a/dist/quill.core.js
+++ b/dist/quill.core.js
@@ -9659,7 +9659,7 @@ var Clipboard = function (_Module) {
         delta = new _quillDelta2.default().insert("\n").concat(delta);
       }
       var format = this.quill.getFormat(index);
-      applyFormatToDelta(delta, format, ["list"]);
+      applyFormatToDelta(delta, format, ['list', 'blockquote']);
       return delta;
     }
   }, {

--- a/dist/quill.js
+++ b/dist/quill.js
@@ -10378,7 +10378,7 @@ var Clipboard = function (_Module) {
         delta = new _quillDelta2.default().insert("\n").concat(delta);
       }
       var format = this.quill.getFormat(index);
-      applyFormatToDelta(delta, format, ["list"]);
+      applyFormatToDelta(delta, format, ['list', 'blockquote']);
       return delta;
     }
   }, {

--- a/dist/unit.js
+++ b/dist/unit.js
@@ -10378,7 +10378,7 @@ var Clipboard = function (_Module) {
         delta = new _quillDelta2.default().insert("\n").concat(delta);
       }
       var format = this.quill.getFormat(index);
-      applyFormatToDelta(delta, format, ["list"]);
+      applyFormatToDelta(delta, format, ['list', 'blockquote']);
       return delta;
     }
   }, {
@@ -15686,15 +15686,31 @@ describe('Clipboard', function () {
       }, 2);
     });
 
-    it('paste list', function (done) {
+    it('paste into list', function (done) {
       var _this8 = this;
+
+      var originalDelta = new _quillDelta2.default().insert("AA").insert("\n", { list: "bullet" }).insert("BB").insert("\n", { list: "bullet" });
+      var expectedDelta = new _quillDelta2.default().insert("AQ").insert("\n", { list: "bullet" }).insert("WA").insert("\n", { list: "bullet" }).insert("BB").insert("\n", { list: "bullet" });
+
+      this.quill.setContents(originalDelta);
+      this.quill.setSelection(1, 0);
+      var event = buildClipboardEvent(null, 'Q<br>W');
+      this.quill.clipboard.onPaste(event);
+      setTimeout(function () {
+        expect(_this8.quill.getContents()).toEqual(expectedDelta);
+        done();
+      }, 2);
+    });
+
+    it('paste list', function (done) {
+      var _this9 = this;
 
       this.quill.setContents(new _quillDelta2.default().insert("AA"));
       this.quill.setSelection(1, 0);
       var event = buildClipboardEvent('<ul><li>B</li></ul>', 'B');
       this.quill.clipboard.onPaste(event);
       setTimeout(function () {
-        expect(_this8.quill.getContents()).toEqual(new _quillDelta2.default().insert("A\nB").insert("\n", { list: "bullet" }).insert("A\n"));
+        expect(_this9.quill.getContents()).toEqual(new _quillDelta2.default().insert("A\nB").insert("\n", { list: "bullet" }).insert("A\n"));
         done();
       }, 2);
     });

--- a/modules/clipboard.js
+++ b/modules/clipboard.js
@@ -158,7 +158,7 @@ class Clipboard extends Module {
         delta = new Delta().insert("\n").concat(delta);
       }
       var format = this.quill.getFormat(index);
-      applyFormatToDelta(delta, format, ["list"])
+      applyFormatToDelta(delta, format, ['list', 'blockquote'])
       return delta;
   }
 

--- a/test/unit/modules/clipboard.js
+++ b/test/unit/modules/clipboard.js
@@ -80,6 +80,28 @@ describe('Clipboard', function() {
       }, 2);
     });
 
+    it('paste into list', function(done) {
+      let originalDelta = new Delta().insert("AA")
+                                        .insert("\n", {list:"bullet"})
+                                        .insert("BB")
+                                        .insert("\n", {list:"bullet"});
+      let expectedDelta = new Delta().insert("AQ")
+                                        .insert("\n", {list:"bullet"})
+                                        .insert("WA")
+                                        .insert("\n", {list:"bullet"})
+                                        .insert("BB")
+                                        .insert("\n", {list:"bullet"});
+
+      this.quill.setContents(originalDelta);
+      this.quill.setSelection(1, 0);
+      let event = buildClipboardEvent(null, 'Q<br>W');
+      this.quill.clipboard.onPaste(event);
+      setTimeout(() => {
+        expect(this.quill.getContents()).toEqual(expectedDelta);
+        done();
+      }, 2);
+    });
+
     it('paste list', function(done) {
       this.quill.setContents(new Delta().insert("AA"));
       this.quill.setSelection(1, 0)


### PR DESCRIPTION
When pasting into list or quote we don't want to break them