### PR TITLE
SPX-8636 - Fix dictation issues on osx

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6918,9 +6918,8 @@
       }
     },
     "parchment": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/parchment/-/parchment-1.1.4.tgz",
-      "integrity": "sha512-J5FBQt/pM2inLzg4hEWmzQx/8h8D0CiDxaG3vyp9rKrQRSDgBlhjdP5jQGgosEajXPSQouXGHOmVdgo7QmJuOg=="
+      "version": "github:readdle/parchment#c7bbf979dcb622fb08c7ddb604077a775344515d",
+      "from": "github:readdle/parchment#fix/SPX-8636-safari_dictation_workaround"
     },
     "parse-asn1": {
       "version": "5.1.5",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "deep-equal": "^1.0.1",
     "eventemitter3": "^2.0.3",
     "extend": "^3.0.1",
-    "parchment": "^1.1.4",
+    "parchment": "github:readdle/parchment#v1.1.4.1",
     "quill-delta": "^3.6.2"
   },
   "devDependencies": {


### PR DESCRIPTION
During dictation on osx webkit sends multiple mutations, some of which results in empty content. In the same time it renders the real input, so for as it means that Quill will think that composer is empty and display placeholder, but real rendering will display some text.